### PR TITLE
feat(taddy): add "_" class to maintain specificity

### DIFF
--- a/@taddy/babel-plugin/src/tests/index.test.ts
+++ b/@taddy/babel-plugin/src/tests/index.test.ts
@@ -99,16 +99,16 @@ describe('taddy.macro', () => {
             `),
         ).toMatchInlineSnapshot(`
             "import { css } from "@taddy/core";
-            import ".cache/taddy/j5kqa5/ys50qh.taddy.css";
+            import ".cache/taddy/j5kqa5/nw43nd.taddy.css";
             export default css("_1kgt43_ndbh _-1p9wvz_-wkmtks_1kgt43_2f0x _-1p9wvz_-wkmtks_t3u24i_1kgt43_1w6ov _-1p9wvz_-wjj8e2_1kgt43_bckm45 _-1p9wvz_-wjj8e2_t3u24i_1kgt43_bchb3k _w0o0bo_-wk67x2_1kgt43_-c55ax8 _w0o0bo_-wk67x2_t3u24i_1kgt43_1svoa _w0o0bo_-wiiu4z_1kgt43_1mpr0j _w0o0bo_-wiiu4z_t3u24i_1kgt43_-g5na6c", "__17gkjp6");"
         `);
 
         expect(getStyles()).toMatchInlineSnapshot(`
             "._1kgt43_ndbh { color: #000; }
-            @container (min-width: 250px) { ._-1p9wvz_-wkmtks_1kgt43_2f0x { color: red; }._-1p9wvz_-wkmtks_t3u24i_1kgt43_1w6ov:hover { color: grey; } }
-            @container (min-width: 450px) { ._-1p9wvz_-wjj8e2_1kgt43_bckm45 { color: lightgrey; }._-1p9wvz_-wjj8e2_t3u24i_1kgt43_bchb3k:hover { color: lightblue; } }
-            @media (min-width: 300px) { ._w0o0bo_-wk67x2_1kgt43_-c55ax8 { color: yellow; }._w0o0bo_-wk67x2_t3u24i_1kgt43_1svoa:hover { color: blue; } }
-            @media (min-width: 600px) { ._w0o0bo_-wiiu4z_1kgt43_1mpr0j { color: green; }._w0o0bo_-wiiu4z_t3u24i_1kgt43_-g5na6c:hover { color: purple; } }"
+            @container (min-width: 250px) { ._._-1p9wvz_-wkmtks_1kgt43_2f0x { color: red; }._._-1p9wvz_-wkmtks_t3u24i_1kgt43_1w6ov:hover { color: grey; } }
+            @container (min-width: 450px) { ._._-1p9wvz_-wjj8e2_1kgt43_bckm45 { color: lightgrey; }._._-1p9wvz_-wjj8e2_t3u24i_1kgt43_bchb3k:hover { color: lightblue; } }
+            @media (min-width: 300px) { ._._w0o0bo_-wk67x2_1kgt43_-c55ax8 { color: yellow; }._._w0o0bo_-wk67x2_t3u24i_1kgt43_1svoa:hover { color: blue; } }
+            @media (min-width: 600px) { ._._w0o0bo_-wiiu4z_1kgt43_1mpr0j { color: green; }._._w0o0bo_-wiiu4z_t3u24i_1kgt43_-g5na6c:hover { color: purple; } }"
         `);
     });
 
@@ -130,7 +130,7 @@ describe('taddy.macro', () => {
             `),
         ).toMatchInlineSnapshot(`
             "import { css } from "taddy";
-            import ".cache/taddy/j5kqa5/1qmg9uk.taddy.css";
+            import ".cache/taddy/j5kqa5/1gblrh.taddy.css";
             const colors = ['violet', 'pink'];
             export default css({
               "_1kgt43": "_-t7a17f",
@@ -143,7 +143,7 @@ describe('taddy.macro', () => {
 
         expect(getStyles()).toMatchInlineSnapshot(`
             "._1kgt43_-t7a17f { color: var(--_1kgt43); }
-            @media (min-width: 300px) { ._w0o0bo_-wk67x2_1kgt43_2f0x { color: red; } }"
+            @media (min-width: 300px) { ._._w0o0bo_-wk67x2_1kgt43_2f0x { color: red; } }"
         `);
     });
 });

--- a/@taddy/core/index.test.ts
+++ b/@taddy/core/index.test.ts
@@ -24,7 +24,7 @@ describe('@taddy/core', () => {
                 '__id2',
             ).className,
         ).toEqual(
-            `${getClassName('color', 'blue')} ${getClassName(
+            `_ ${getClassName('color', 'blue')} ${getClassName(
                 'background',
                 'blue',
             )} __id1 __id2`,
@@ -39,7 +39,7 @@ describe('@taddy/core', () => {
                 '__id2',
             ).className,
         ).toEqual(
-            `${getClassName('color', 'red')} ${getClassName(
+            `_ ${getClassName('color', 'red')} ${getClassName(
                 'background',
                 'blue',
             )} __id1 __id2`,

--- a/@taddy/core/static/index.ts
+++ b/@taddy/core/static/index.ts
@@ -8,10 +8,14 @@ export const mapStaticClassName = (className?: string): object => {
     const v = staticCache[className];
     if (v) return v;
     return (staticCache[className] = className.split(' ').reduce((acc, v) => {
+        if (v === '_') return acc;
+
+        // ignore classes which don't have '_' prefix or have '__' prefix
         if (v[0] !== '_' || v[1] === '_') {
             acc[v] = true;
             return acc;
         }
+
         const hashes = v.split('_');
         if (hashes.length === 2) {
             acc[v] = true;
@@ -19,6 +23,7 @@ export const mapStaticClassName = (className?: string): object => {
             const lastHash = hashes.pop();
             acc[hashes.join('_')] = '_' + lastHash;
         }
+
         return acc;
     }, {}));
 };
@@ -93,7 +98,8 @@ const _css = (
         }
     }
 
-    result.className = joinClassName(className);
+    // append "_" to the final className to maintain specificity
+    result.className = '_ ' + joinClassName(className);
 
     if (style) {
         result.style = style;

--- a/taddy/RuleInjector/StyleSheet.ts
+++ b/taddy/RuleInjector/StyleSheet.ts
@@ -99,12 +99,15 @@ export class StyleSheet extends Sheet {
             return -1;
         }
 
-        const selectorText = `.${className}`;
+        const isAtRule = atRuleIndex !== undefined;
+
+        const selectorPrefix = isAtRule ? '._' : '';
+        const selectorText = selectorPrefix + `.${className}`;
         const cssText = buildAtomicRule(selectorText, key, value);
 
         let insertSheet = this.sheet;
 
-        if (atRuleIndex !== undefined) {
+        if (isAtRule) {
             // cast at rule type
             insertSheet = this.cssRules[
                 atRuleIndex

--- a/taddy/RuleInjector/VirtualStyleSheet.ts
+++ b/taddy/RuleInjector/VirtualStyleSheet.ts
@@ -45,12 +45,15 @@ export class VirtualStyleSheet extends Sheet {
             atRuleIndex,
         }: {postfix?: string; atRuleIndex?: number} = {},
     ): number {
-        const selectorText = `.${className}`;
+        const isAtRule = atRuleIndex !== undefined;
+
+        const selectorPrefix = isAtRule ? '._' : '';
+        const selectorText = selectorPrefix + `.${className}`;
         const cssText = buildAtomicRule(selectorText, key, value);
 
         let insertSheet = this.sheet;
 
-        if (atRuleIndex !== undefined) {
+        if (isAtRule) {
             // cast media rule type
             insertSheet = this.sheet.cssRules[
                 atRuleIndex

--- a/taddy/index.ts
+++ b/taddy/index.ts
@@ -54,7 +54,8 @@ function _css<T extends TaddyRule | {[key: string]: TaddyRule}>(
     delete result.className[MIXIN_KEY];
 
     // @ts-expect-error fix types
-    result.className = joinClassName(result.className);
+    // append "_" to the final className to maintain specificity
+    result.className = '_ ' + joinClassName(result.className);
 
     return withId(result, id);
 }

--- a/taddy/tests/index.test.ts
+++ b/taddy/tests/index.test.ts
@@ -30,8 +30,8 @@ describe('api', () => {
     it('should generate atoms', () => {
         expect(css({color: 'red', background: 'green'})).toMatchInlineSnapshot(`
             {
-              "className": "_1kgt43_2f0x _-m15jgy_1mpr0j ___jtqwen",
-              Symbol(ID_KEY): "___jtqwen",
+              "className": "_ _1kgt43_2f0x _-m15jgy_1mpr0j ___lp7ldc",
+              Symbol(ID_KEY): "___lp7ldc",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
@@ -52,8 +52,8 @@ describe('api', () => {
             }),
         ).toMatchInlineSnapshot(`
             {
-              "className": "_-kygmid_1c _rnbphe_1vf95 ___86u29p",
-              Symbol(ID_KEY): "___86u29p",
+              "className": "_ _-kygmid_1c _rnbphe_1vf95 ___sba9to",
+              Symbol(ID_KEY): "___sba9to",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
@@ -259,16 +259,16 @@ describe('api', () => {
 
         expect(button).toMatchInlineSnapshot(`
             {
-              "className": "_1kgt43_2f0x ___6zzohd",
-              Symbol(ID_KEY): "___6zzohd",
+              "className": "_ _1kgt43_2f0x ___-wnp3vy",
+              Symbol(ID_KEY): "___-wnp3vy",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
 
         expect(box).toMatchInlineSnapshot(`
             {
-              "className": "_1kgt43_1svoa _ea88or_fk903q_wcpz ___r2si3",
-              Symbol(ID_KEY): "___r2si3",
+              "className": "_ _1kgt43_1svoa _ozbvb8_fk903q_wcpz ___39by3k",
+              Symbol(ID_KEY): "___39by3k",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
@@ -276,7 +276,7 @@ describe('api', () => {
         expect(getStyles()).toMatchInlineSnapshot(`
             "._1kgt43_2f0x { color: red; }
             ._1kgt43_1svoa { color: blue; }
-            ._ea88or_fk903q_wcpz + .___6zzohd { margin-left: 10px; }"
+            ._ozbvb8_fk903q_wcpz + .___-wnp3vy { margin-left: 10px; }"
         `);
     });
 
@@ -328,15 +328,15 @@ describe('api', () => {
 
         expect(button).toMatchInlineSnapshot(`
             {
-              "className": "_1kgt43_1svoa _w0o0bo_-wl9t3s_1kgt43_2f0x ___-xdchlh",
-              Symbol(ID_KEY): "___-xdchlh",
+              "className": "_ _1kgt43_1svoa _w0o0bo_-wl9t3s_1kgt43_2f0x ___cd9162",
+              Symbol(ID_KEY): "___cd9162",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
 
         expect(getStyles()).toMatchInlineSnapshot(`
             "._1kgt43_1svoa { color: blue; }
-            @media (min-width: 100px) { ._w0o0bo_-wl9t3s_1kgt43_2f0x { color: red; } }"
+            @media (min-width: 100px) { ._._w0o0bo_-wl9t3s_1kgt43_2f0x { color: red; } }"
         `);
     });
 
@@ -348,15 +348,15 @@ describe('api', () => {
 
         expect(button).toMatchInlineSnapshot(`
             {
-              "className": "_1kgt43_1svoa _-1p9wvz_-wl9t3s_1kgt43_2f0x ___xs95gy",
-              Symbol(ID_KEY): "___xs95gy",
+              "className": "_ _1kgt43_1svoa _-1p9wvz_-wl9t3s_1kgt43_2f0x ___v2j7o3",
+              Symbol(ID_KEY): "___v2j7o3",
               Symbol(Symbol.toPrimitive): [Function],
             }
         `);
 
         expect(getStyles()).toMatchInlineSnapshot(`
             "._1kgt43_1svoa { color: blue; }
-            @container (min-width: 100px) { ._-1p9wvz_-wl9t3s_1kgt43_2f0x { color: red; } }"
+            @container (min-width: 100px) { ._._-1p9wvz_-wl9t3s_1kgt43_2f0x { color: red; } }"
         `);
     });
 


### PR DESCRIPTION
add extra `_` class in the resulting class name, to maintain specificity in selectors. for example, media selectors now got increased specificity by composing with `_`

```css
@container (min-width: 250px) {
  ._.hash { color: blue; }
}
```